### PR TITLE
Use Rayon to parallelize radius check

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,3 +5,5 @@ The mathematical version of Hello, World: Calculating pi by integrating the unit
 The implementation is duplicated in Python for benchmarking, which shows that `cargo run --release` yields a 20x speedup over the matching Python implementation, while without the release optimizations the Rust implementation is actually slower.
 
 Implementing parallelization with Rayon and an anonymous function, but updating the benchmark to use numpy's random generation for a vector doesn't change the speedup ratio: Rust remains 20x faster but coming up on 30x faster at 10M samples.
+
+Further improving the Rayon parallelization and expanding its use reduces the runtime further, but updating the Python benchmark to utilize numpy arrays and vectorization closes the performance gap to only 10x better for rust.

--- a/python_benchmark/main.py
+++ b/python_benchmark/main.py
@@ -29,16 +29,11 @@ def main():
 
     time_start = time.time()
     count = 0
-    x = rng.random(n_samples)
-    y = rng.random(n_samples)
+    coords = rng.random((n_samples, 2))
+    radii = coords[:, 0] ** 2 + coords[:, 1] ** 2
+    in_circle = radii <= RADIUS_SQ
+    count = sum(in_circle)
 
-    for i in range(n_samples):
-        x_sample = x[i]
-        y_sample = y[i]
-        sample_radius_sq = x_sample * x_sample + y_sample * y_sample
-        in_circle = sample_radius_sq <= RADIUS_SQ
-        if in_circle:
-            count += 1
     time_end = time.time()
 
     print(f"n_samples: {n_samples}")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,21 +14,15 @@ pub mod utils {
     }
 
     pub fn estimate_pi(&n_samples: &i32) -> f64 {
-        let mut count = 0;
         let coords = generate_coords(n_samples);
 
-        for i in 0..=n_samples - 1 {
-            let (x_sample, y_sample) = coords[i as usize];
+        let inside: Vec<bool> = coords
+            .into_par_iter()
+            .map(|(x_s, y_s)| (x_s * x_s + y_s * y_s) <= super::RADIUS_SQ)
+            .collect();
+        let count_map: f64 = inside.into_iter().filter(|&b| b).count() as f64;
 
-            let sample_radius_sq = x_sample * x_sample + y_sample * y_sample;
-            let in_circle: bool = sample_radius_sq <= super::RADIUS_SQ;
-
-            if in_circle {
-                count += 1
-            }
-        }
-
-        let pi: f64 = 4.0 * count as f64 / n_samples as f64;
+        let pi: f64 = 4.0 * count_map / n_samples as f64;
         pi
     }
 }


### PR DESCRIPTION
Radius check is currently done in a for loop, parallelize this to further improve performance.

Regularly seeing under 68000 microseconds for 10,000,000 samples in rust, which remains 10x faster than Python despite numpy arrays and vectorization in the benchmark.